### PR TITLE
let the vscode task run on Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,19 +3,14 @@
   "options": {
     "cwd": "."
   },
-  "windows": {
-    "options": {
-      "shell": {
-        "executable": "C:\\Program Files\\Git\\bin\\bash.exe",
-        "args": ["-c"]
-      }
-    }
-  },
   "tasks": [
     {
       "label": "Start Simulator",
       "type": "shell",
       "command": "./start-simulator.sh",
+      "windows": {
+        "command": "./start-simulator.ps1"
+      },
       "group": {
         "kind": "build",
         "isDefault": false

--- a/start-simulator.ps1
+++ b/start-simulator.ps1
@@ -1,0 +1,4 @@
+cd ./.deps/pxl-simulator
+npm i
+npm run build
+npm run dev


### PR DESCRIPTION
With this change, people on Windows can use the task from VSCode independent of their git installation